### PR TITLE
chore(workflow): switch release changelog from PR-based to commit-log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,20 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: '1'
 
+      - name: Generate commit-based changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo '')
+          if [ -z "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:'- %s (%h)' HEAD)
+          else
+            NOTES=$(git log --pretty=format:'- %s (%h)' "${PREV_TAG}..HEAD")
+          fi
+          echo "NOTES<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.NOTES }}
           make_latest: true

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -64,7 +64,10 @@ Langkah yang dijalankan:
 2. Setup Node.js 24 + cache npm
 3. `npm ci`
 4. `npm run build`
-5. Membuat GitHub Release otomatis dengan release notes yang di-generate dari PR yang sudah di-merge
+5. Generate changelog otomatis dari **commit log** antara tag sebelumnya dan tag baru
+6. Membuat GitHub Release dengan changelog commit
+
+> **Catatan**: Changelog dibuat dari git commit log, bukan dari PR. Cocok untuk solo developer yang push langsung ke branch utama tanpa PR flow. Format commit Conventional Commits (`feat:`, `fix:`, `chore:` dst.) akan langsung terbaca di release notes.
 
 **Cara membuat release baru:**
 


### PR DESCRIPTION
Solo developer workflow does not use PRs, so generate_release_notes was producing empty changelogs. Replace with a git log step that diffs commits between the previous and current tag. First release captures full history.