### PR TITLE
Add license section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ Mulai dari:
 ## Status Project
 
 Status: aktif dikembangkan. Dokumentasi ini mengikuti kondisi repository saat ini dan perlu ikut diperbarui setiap ada perubahan fitur, database, auth, environment variable, deployment, security, atau struktur folder.
+
+## Lisensi
+
+[MIT License](./LICENSE) — Copyright © 2026 Kupzed


### PR DESCRIPTION
Add a new 'Lisensi' section to README.md linking to the project's LICENSE file and adding an MIT copyright notice for 2026 Kupzed.