### PR TITLE
feat(transaksi): convert filters to multi-select combo dropdowns

### DIFF
--- a/docs/features/transaksi.md
+++ b/docs/features/transaksi.md
@@ -70,8 +70,8 @@ Initial data diambil di Server Component dengan:
 
 ## UI Behavior
 
-- User bisa filter periode, tipe, rekening, search judul/catatan/kategori, dan sorting.
-- Pada mobile, filter urutan dan tipe tampil dalam dua kolom, sedangkan filter rekening memakai satu baris penuh agar label tidak terpotong. Mulai breakpoint `sm`, ketiganya kembali sejajar dalam satu baris.
+- User bisa filter periode, tipe (multi-select), rekening (multi-select), kategori (multi-select), search judul/catatan/kategori, dan sorting.
+- Filter tipe, rekening, dan kategori mendukung combo/multi-select: user bisa memilih beberapa opsi sekaligus. Sorting tetap single-select. Filter tampil dalam grid dua kolom pada mobile dan empat kolom mulai breakpoint `sm`.
 - Query `?new=true` membuka dialog transaksi baru otomatis.
 - Dialog mendukung mode create, edit, copy, dan correction readonly behavior.
 - Dialog mobile dipusatkan di area aman dan memisahkan frame tetap dari scroll container form. Struktur ini menjaga tombol aksi tetap normal setelah momentum scroll cepat di iOS/PWA.

--- a/docs/server-actions-api.md
+++ b/docs/server-actions-api.md
@@ -185,15 +185,15 @@ Tabel: `kategori`.
 
 Lokasi: `src/actions/transaksi-action.ts`
 
-Deskripsi: mengambil transaksi dengan relasi kategori, rekening asal, dan rekening tujuan. Filter `q` mencocokkan judul, catatan, dan nama kategori.
+Deskripsi: mengambil transaksi dengan relasi kategori, rekening asal, dan rekening tujuan. Filter `q` mencocokkan judul, catatan, dan nama kategori. Field `tipe`, `rekening_id`, dan `kategori_id` mendukung multi-select (array); array kosong berarti "semua".
 
 Input:
 
 ```ts
 type TransaksiFilter = {
-  tipe?: "income" | "expense" | "transfer" | "correction" | "all";
-  rekening_id?: string;
-  kategori_id?: string;
+  tipe?: TipeTransaksi[];
+  rekening_id?: string[];
+  kategori_id?: string[];
   dari?: string;
   sampai?: string;
   q?: string;
@@ -344,10 +344,10 @@ Tabel: `rekening`.
 
 Lokasi: `src/actions/kategori-action.ts`
 
-| Action           | Tujuan                          | Validasi                        | Tabel      |
-| ---------------- | ------------------------------- | ------------------------------- | ---------- |
-| `createKategori` | Membuat kategori custom user.   | `kategoriSchema` (server-side)  | `kategori` |
-| `updateKategori` | Mengubah kategori custom user.  | `kategoriSchema` (server-side)  | `kategori` |
+| Action           | Tujuan                          | Validasi                                      | Tabel      |
+| ---------------- | ------------------------------- | --------------------------------------------- | ---------- |
+| `createKategori` | Membuat kategori custom user.   | `kategoriSchema` (server-side)                | `kategori` |
+| `updateKategori` | Mengubah kategori custom user.  | `kategoriSchema` (server-side)                | `kategori` |
 | `deleteKategori` | Menghapus kategori custom user. | Auth user + `is_system = false` + usage check | `kategori` |
 
 Action update/delete menambahkan filter `user_id = user.id` dan `is_system = false`, selain proteksi RLS.
@@ -362,16 +362,16 @@ Proteksi tambahan:
 
 Lokasi: `src/actions/hutang-action.ts`
 
-| Action            | Tujuan                                                                | Tabel                      |
-| ----------------- | --------------------------------------------------------------------- | -------------------------- |
-| `getHutang`       | Mengambil hutang/piutang dengan relasi cicilan.                       | `hutang`, `hutang_cicilan` |
-| `createHutang`    | Membuat hutang/piutang. Validasi `hutangSchema` server-side.          | `hutang`                   |
+| Action            | Tujuan                                                                                                                                                           | Tabel                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `getHutang`       | Mengambil hutang/piutang dengan relasi cicilan.                                                                                                                  | `hutang`, `hutang_cicilan` |
+| `createHutang`    | Membuat hutang/piutang. Validasi `hutangSchema` server-side.                                                                                                     | `hutang`                   |
 | `updateHutang`    | Mengubah hutang/piutang. Validasi `hutangSchema.partial()` server-side. Menghitung ulang sisa jika total berubah. Menolak perubahan tipe jika sudah ada cicilan. | `hutang`, `hutang_cicilan` |
-| `deleteHutang`    | Menghapus hutang/piutang.                                             | `hutang`                   |
-| `createCicilan`   | Membuat cicilan. Validasi `cicilanSchema` server-side. Mengembalikan parent `Hutang` terbaru. | `hutang_cicilan`, `hutang` |
-| `updateCicilan`   | Mengubah nominal, tanggal, waktu, rekening, atau catatan cicilan lalu mengembalikan parent `Hutang` terbaru. | `hutang_cicilan`, `hutang` |
-| `deleteCicilan`   | Menghapus cicilan lalu mengembalikan parent `Hutang` terbaru.         | `hutang_cicilan`, `hutang` |
-| `markHutangLunas` | Membuat cicilan sebesar sisa tagihan dengan rekening opsional.        | `hutang_cicilan`, `hutang` |
+| `deleteHutang`    | Menghapus hutang/piutang.                                                                                                                                        | `hutang`                   |
+| `createCicilan`   | Membuat cicilan. Validasi `cicilanSchema` server-side. Mengembalikan parent `Hutang` terbaru.                                                                    | `hutang_cicilan`, `hutang` |
+| `updateCicilan`   | Mengubah nominal, tanggal, waktu, rekening, atau catatan cicilan lalu mengembalikan parent `Hutang` terbaru.                                                     | `hutang_cicilan`, `hutang` |
+| `deleteCicilan`   | Menghapus cicilan lalu mengembalikan parent `Hutang` terbaru.                                                                                                    | `hutang_cicilan`, `hutang` |
+| `markHutangLunas` | Membuat cicilan sebesar sisa tagihan dengan rekening opsional.                                                                                                   | `hutang_cicilan`, `hutang` |
 
 Validasi server-side:
 
@@ -384,13 +384,13 @@ Catatan: operasi cicilan mengandalkan trigger database untuk memperbarui `sisa_t
 
 Lokasi: `src/actions/rekap-action.ts`
 
-| Action                                  | Tujuan                                                                                                           | Tabel                                        |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| `getRekapBulanan(tahun)`                | Menghitung income, expense, dan net per bulan. Transfer dan correction tidak masuk total utama.                   | `transaksi`                                  |
-| `getRekapDetailBulanan(bulan, tahun)`   | Mengambil detail bulan: selisih utama, breakdown kategori/judul, koreksi saldo, aktivitas hutang/piutang, dan sisa aktif. | `transaksi`, `kategori`, `rekening`, `hutang`, `hutang_cicilan` |
-| `getRekapKategori(bulan, tahun)`        | Breakdown expense per kategori untuk bulan tertentu.                                                             | `transaksi`, `kategori`                      |
-| `getBudgetWithUsage(bulan, tahun)`      | Mengambil budget dan menghitung pemakaian expense.                                                               | `budget`, `transaksi`, `kategori`            |
-| `upsertBudget(...)`                     | Membuat/mengubah budget berdasarkan unique `(user_id,kategori_id,bulan,tahun)`.                                  | `budget`                                     |
+| Action                                | Tujuan                                                                                                                    | Tabel                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `getRekapBulanan(tahun)`              | Menghitung income, expense, dan net per bulan. Transfer dan correction tidak masuk total utama.                           | `transaksi`                                                     |
+| `getRekapDetailBulanan(bulan, tahun)` | Mengambil detail bulan: selisih utama, breakdown kategori/judul, koreksi saldo, aktivitas hutang/piutang, dan sisa aktif. | `transaksi`, `kategori`, `rekening`, `hutang`, `hutang_cicilan` |
+| `getRekapKategori(bulan, tahun)`      | Breakdown expense per kategori untuk bulan tertentu.                                                                      | `transaksi`, `kategori`                                         |
+| `getBudgetWithUsage(bulan, tahun)`    | Mengambil budget dan menghitung pemakaian expense.                                                                        | `budget`, `transaksi`, `kategori`                               |
+| `upsertBudget(...)`                   | Membuat/mengubah budget berdasarkan unique `(user_id,kategori_id,bulan,tahun)`.                                           | `budget`                                                        |
 
 Catatan: `upsertBudget` belum terlihat dipakai oleh UI route yang ada.
 
@@ -438,7 +438,7 @@ Deskripsi: mengubah sebagian preferensi sistem user dengan runtime validation wh
 Input:
 
 ```ts
-Partial<UserPreferences>
+Partial<UserPreferences>;
 ```
 
 Output:

--- a/src/actions/transaksi-action.ts
+++ b/src/actions/transaksi-action.ts
@@ -61,14 +61,14 @@ export async function getTransaksi(filter: TransaksiFilter = {}): Promise<Transa
     query = query.order('waktu', { ascending: filter.sortOrder === 'asc' }).order('created_at', { ascending: filter.sortOrder === 'asc' });
   }
 
-  if (filter.tipe && filter.tipe !== 'all') {
-    query = query.eq('tipe', filter.tipe);
+  if (filter.tipe?.length) {
+    query = query.in('tipe', filter.tipe);
   }
-  if (filter.rekening_id) {
-    query = query.eq('rekening_id', filter.rekening_id);
+  if (filter.rekening_id?.length) {
+    query = query.in('rekening_id', filter.rekening_id);
   }
-  if (filter.kategori_id) {
-    query = query.eq('kategori_id', filter.kategori_id);
+  if (filter.kategori_id?.length) {
+    query = query.in('kategori_id', filter.kategori_id);
   }
   if (filter.dari) {
     query = query.gte('tanggal', filter.dari);

--- a/src/app/(dashboard)/transaksi/_components/transaksi-filter-bar.tsx
+++ b/src/app/(dashboard)/transaksi/_components/transaksi-filter-bar.tsx
@@ -2,7 +2,7 @@
 
 import type { Dispatch, SetStateAction } from "react";
 import type { Rekening } from "@/types/rekening";
-import type { TransaksiFilter } from "@/types/transaksi";
+import type { Kategori, TransaksiFilter, TipeTransaksi } from "@/types/transaksi";
 import { Button } from "@/components/ui/button";
 import { ClearableInput } from "@/components/common/clearable-input";
 import {
@@ -12,8 +12,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { RekeningSelect } from "@/components/common/rekening-select";
-import { Plus, Search } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Badge } from "@/components/ui/badge";
+import { ChevronDown, Plus, Search } from "lucide-react";
 
 export type TransaksiFilterBarProps = {
   search: string;
@@ -21,8 +29,35 @@ export type TransaksiFilterBarProps = {
   filter: TransaksiFilter;
   onFilterChange: Dispatch<SetStateAction<TransaksiFilter>>;
   rekening: Rekening[];
+  kategori: Kategori[];
   onAddClick: () => void;
 };
+
+/* ------------------------------------------------------------------ */
+/*  Helper: toggle item di dalam array                                 */
+/* ------------------------------------------------------------------ */
+function toggleArrayItem<T>(arr: T[] | undefined, item: T): T[] {
+  const current = arr ?? [];
+  return current.includes(item)
+    ? current.filter((i) => i !== item)
+    : [...current, item];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tipe options                                                       */
+/* ------------------------------------------------------------------ */
+const TIPE_OPTIONS: { value: TipeTransaksi; label: string }[] = [
+  { value: "income", label: "Pemasukan" },
+  { value: "expense", label: "Pengeluaran" },
+  { value: "transfer", label: "Transfer" },
+  { value: "correction", label: "Koreksi Saldo" },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Shared trigger className                                           */
+/* ------------------------------------------------------------------ */
+const triggerClassName =
+  "flex h-12 w-full items-center justify-between gap-1 rounded-input border border-hairline bg-background px-3 py-2 text-sm text-foreground transition-colors hover:bg-surface-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:bg-card [&>svg]:shrink-0 [&>svg]:text-muted-foreground";
 
 export function TransaksiFilterBar({
   search,
@@ -30,8 +65,36 @@ export function TransaksiFilterBar({
   filter,
   onFilterChange,
   rekening,
+  kategori,
   onAddClick,
 }: TransaksiFilterBarProps) {
+  /* ---- tipe helpers ---- */
+  const selectedTipe = filter.tipe ?? [];
+  const tipeLabel =
+    selectedTipe.length === 0
+      ? "Semua Tipe"
+      : selectedTipe.length === 1
+        ? TIPE_OPTIONS.find((o) => o.value === selectedTipe[0])?.label ?? "Tipe"
+        : `Tipe`;
+
+  /* ---- rekening helpers ---- */
+  const selectedRek = filter.rekening_id ?? [];
+  const rekLabel =
+    selectedRek.length === 0
+      ? "Semua Rekening"
+      : selectedRek.length === 1
+        ? rekening.find((r) => r.id === selectedRek[0])?.nama ?? "Rekening"
+        : `Rekening`;
+
+  /* ---- kategori helpers ---- */
+  const selectedKat = filter.kategori_id ?? [];
+  const katLabel =
+    selectedKat.length === 0
+      ? "Semua Kategori"
+      : selectedKat.length === 1
+        ? kategori.find((k) => k.id === selectedKat[0])?.nama ?? "Kategori"
+        : `Kategori`;
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col sm:flex-row gap-2">
@@ -47,7 +110,7 @@ export function TransaksiFilterBar({
         </div>
         <Button
           onClick={onAddClick}
-          className="h-11 px-5 bg-primary hover:bg-[#003ecc] text-white rounded-full font-semibold gap-2 shrink-0 transition-colors"
+          className="h-12 px-5 bg-primary hover:bg-[#003ecc] text-white rounded-full font-semibold gap-2 shrink-0 transition-colors"
           id="btn-tambah-transaksi"
         >
           <Plus className="h-4 w-4" />
@@ -55,7 +118,8 @@ export function TransaksiFilterBar({
         </Button>
       </div>
 
-      <div className="grid w-full grid-cols-2 gap-2 sm:grid-cols-3">
+      <div className="grid w-full grid-cols-2 gap-2 sm:grid-cols-4">
+        {/* ── Sort (tetap single-select) ── */}
         <Select
           value={`${filter.sortBy}-${filter.sortOrder}`}
           onValueChange={(v) => {
@@ -68,7 +132,7 @@ export function TransaksiFilterBar({
         >
           <SelectTrigger
             size="sm"
-            className="h-11! min-w-0 text-sm text-foreground border-hairline"
+            className="h-12! min-w-0 text-sm text-foreground border-hairline"
             id="filter-sort"
           >
             <SelectValue placeholder="Urutkan" />
@@ -89,47 +153,146 @@ export function TransaksiFilterBar({
           </SelectContent>
         </Select>
 
-        <Select
-          value={filter.tipe ?? "all"}
-          onValueChange={(v) =>
-            onFilterChange((f) => ({
-              ...f,
-              tipe: v as TransaksiFilter["tipe"],
-            }))
-          }
-        >
-          <SelectTrigger
-            size="sm"
-            className="h-11! min-w-0 text-sm text-foreground border-hairline"
-            id="filter-tipe"
-          >
-            <SelectValue placeholder="Semua tipe" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Semua Tipe</SelectItem>
-            <SelectItem value="income">Pemasukan</SelectItem>
-            <SelectItem value="expense">Pengeluaran</SelectItem>
-            <SelectItem value="transfer">Transfer</SelectItem>
-            <SelectItem value="correction">Koreksi Saldo</SelectItem>
-          </SelectContent>
-        </Select>
+        {/* ── Tipe (multi-select) ── */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className={triggerClassName}
+              id="filter-tipe"
+            >
+              <span className="flex items-center gap-1.5 truncate">
+                <span className="truncate">{tipeLabel}</span>
+                {selectedTipe.length > 0 && (
+                  <Badge
+                    variant="secondary"
+                    className="text-[10px] px-1.5 py-0 h-4 min-w-4 flex items-center justify-center"
+                  >
+                    {selectedTipe.length}
+                  </Badge>
+                )}
+              </span>
+              <ChevronDown className="h-4 w-4 opacity-50" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-48">
+            <DropdownMenuLabel>Tipe Transaksi</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {TIPE_OPTIONS.map((opt) => (
+              <DropdownMenuCheckboxItem
+                key={opt.value}
+                checked={selectedTipe.includes(opt.value)}
+                onCheckedChange={() =>
+                  onFilterChange((f) => ({
+                    ...f,
+                    tipe: toggleArrayItem(f.tipe, opt.value),
+                  }))
+                }
+                onSelect={(e) => e.preventDefault()}
+              >
+                {opt.label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-        <RekeningSelect
-          rekening={rekening}
-          value={filter.rekening_id ?? "none"}
-          onValueChange={(v) =>
-            onFilterChange((f) => ({
-              ...f,
-              rekening_id: v === "none" ? undefined : v,
-            }))
-          }
-          placeholder="Semua rekening"
-          includeNone={true}
-          noneLabel="Semua Rekening"
-          size="sm"
-          className="col-span-2 h-11! min-w-0 text-sm text-foreground border-hairline sm:col-span-1"
-          id="filter-rekening"
-        />
+        {/* ── Rekening (multi-select) ── */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className={triggerClassName}
+              id="filter-rekening"
+            >
+              <span className="flex items-center gap-1.5 truncate">
+                <span className="truncate">{rekLabel}</span>
+                {selectedRek.length > 0 && (
+                  <Badge
+                    variant="secondary"
+                    className="text-[10px] px-1.5 py-0 h-4 min-w-4 flex items-center justify-center"
+                  >
+                    {selectedRek.length}
+                  </Badge>
+                )}
+              </span>
+              <ChevronDown className="h-4 w-4 opacity-50" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-48">
+            <DropdownMenuLabel>Rekening</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {rekening.map((r) => (
+              <DropdownMenuCheckboxItem
+                key={r.id}
+                checked={selectedRek.includes(r.id)}
+                onCheckedChange={() =>
+                  onFilterChange((f) => ({
+                    ...f,
+                    rekening_id: toggleArrayItem(f.rekening_id, r.id),
+                  }))
+                }
+                onSelect={(e) => e.preventDefault()}
+              >
+                <span className="flex items-center gap-2">
+                  <span
+                    className="w-2.5 h-2.5 rounded-full shrink-0"
+                    style={{ background: r.warna }}
+                  />
+                  {r.nama}
+                  <span className="text-muted-foreground text-xs ml-1 font-normal">
+                    ({r.jenis})
+                  </span>
+                </span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* ── Kategori (multi-select, baru) ── */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className={triggerClassName}
+              id="filter-kategori"
+            >
+              <span className="flex items-center gap-1.5 truncate">
+                <span className="truncate">{katLabel}</span>
+                {selectedKat.length > 0 && (
+                  <Badge
+                    variant="secondary"
+                    className="text-[10px] px-1.5 py-0 h-4 min-w-4 flex items-center justify-center"
+                  >
+                    {selectedKat.length}
+                  </Badge>
+                )}
+              </span>
+              <ChevronDown className="h-4 w-4 opacity-50" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-48 max-h-64 overflow-y-auto">
+            <DropdownMenuLabel>Kategori</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {kategori.map((k) => (
+              <DropdownMenuCheckboxItem
+                key={k.id}
+                checked={selectedKat.includes(k.id)}
+                onCheckedChange={() =>
+                  onFilterChange((f) => ({
+                    ...f,
+                    kategori_id: toggleArrayItem(f.kategori_id, k.id),
+                  }))
+                }
+                onSelect={(e) => e.preventDefault()}
+              >
+                <span className="flex items-center gap-2">
+                  <span>{k.ikon}</span>
+                  {k.nama}
+                </span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/src/app/(dashboard)/transaksi/_components/transaksi-page-client.tsx
+++ b/src/app/(dashboard)/transaksi/_components/transaksi-page-client.tsx
@@ -285,6 +285,7 @@ export default function TransaksiPageClient({
         filter={filter}
         onFilterChange={setFilter}
         rekening={rekening}
+        kategori={kategori}
         onAddClick={handleAddClick}
       />
 

--- a/src/hooks/use-transaksi-filter.ts
+++ b/src/hooks/use-transaksi-filter.ts
@@ -41,7 +41,9 @@ export function useTransaksiFilter<T extends Transaksi = Transaksi>({
   dateFilter,
 }: UseTransaksiFilterParams<T>): UseTransaksiFilterReturn<T> {
   const [filter, setFilter] = useState<TransaksiFilter>({
-    tipe: "all",
+    tipe: [],
+    rekening_id: [],
+    kategori_id: [],
     sortBy: "tanggal",
     sortOrder: "desc",
   });
@@ -50,11 +52,11 @@ export function useTransaksiFilter<T extends Transaksi = Transaksi>({
   const filtered = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
     const result = transaksi.filter((t) => {
-      if (filter.tipe && filter.tipe !== "all" && t.tipe !== filter.tipe)
+      if (filter.tipe?.length && !filter.tipe.includes(t.tipe))
         return false;
-      if (filter.rekening_id && t.rekening_id !== filter.rekening_id)
+      if (filter.rekening_id?.length && !filter.rekening_id.includes(t.rekening_id ?? ""))
         return false;
-      if (filter.kategori_id && t.kategori_id !== filter.kategori_id)
+      if (filter.kategori_id?.length && !filter.kategori_id.includes(t.kategori_id ?? ""))
         return false;
       if (
         normalizedSearch &&

--- a/src/types/transaksi.d.ts
+++ b/src/types/transaksi.d.ts
@@ -49,9 +49,9 @@ export type TransaksiFormValues = {
 };
 
 export type TransaksiFilter = {
-  tipe?: TipeTransaksi | 'all';
-  rekening_id?: string;
-  kategori_id?: string;
+  tipe?: TipeTransaksi[];      // kosong = semua tipe
+  rekening_id?: string[];      // kosong = semua rekening
+  kategori_id?: string[];      // kosong = semua kategori
   dari?: string;
   sampai?: string;
   q?: string;


### PR DESCRIPTION
Replace single-select Radix Select with DropdownMenu + CheckboxItem for Tipe, Rekening, and Kategori filters on the transaction page. Add new Kategori multi-select filter that was previously missing.

Sort filter (terbaru/terlama/terbesar/terkecil) remains single-select.

Update TransaksiFilter type to use arrays, adjust client-side hook filtering to use .includes(), and server-side action to use Supabase .in() instead of .eq().

Fix filter trigger height from h-11 to h-12 per DESIGN.md spec. Update docs/features/transaksi.md and docs/server-actions-api.md.